### PR TITLE
Remove practitioner element from care plan

### DIFF
--- a/src/pages/CurrentPlan.js
+++ b/src/pages/CurrentPlan.js
@@ -41,36 +41,7 @@ function CarePlanHeader({ currentPlan }) {
   );
 }
 
-// Renders the Practitioner section.
-function Practitioner() {
-  // eventually pull these from carePlan
-  const practitionerName = "Dr. Lauren Potapova";
-  const practitionerPicture = require("../assets/profile-member-03.png");
-  return (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "row",
-        marginTop: "2rem",
-      }}
-    >
-      <Avatar src={practitionerPicture} sx={{ height: 56, width: 56 }} />
 
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "start",
-          marginLeft: "1rem",
-          marginTop: "0.3rem",
-        }}
-      >
-        <Typography variant="eyebrow">Your Practitioner</Typography>
-        <Typography variant="h6">{practitionerName}</Typography>
-      </Box>
-    </Box>
-  );
-}
 
 // Renders the "Last Modified" section.
 function LastModified({ date }) {
@@ -100,7 +71,6 @@ function CurrentPlanWithContent(props) {
       <CarePlanHeader currentPlan={currentPlan} />
 
       <Container sx={{ marginBottom: 5 }}>
-        <Practitioner />
         <RichText
           content={currentPlan.description}
           sx={{


### PR DESCRIPTION
Removing the practitioner element from the Care Plan info page. Why?

- This won't scale when the patient has more than one assigned practitioner
- We currently don't have a way to associate a patient's care team member with a specific care plan, so we'd have to show every practitioner on their care team
- We will still have a way to view your care team + their bios from the profile page

<img width="373" alt="image" src="https://user-images.githubusercontent.com/34405753/180835227-f2287394-09fe-42e0-aaaa-ff894bd26dc7.png">
