### PR TITLE
Create demo flag as env variable and hide patient pages behind flag

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,7 @@
 # Get these values from your Capable Health portal
 REACT_APP_COGNITO_REGION=us-east-1
 REACT_APP_COGNITO_USER_POOL_ID=<<xxxxxxxx>>
+# The ID below should be the End User Login App Client ID
 REACT_APP_COGNITO_USER_POOL_WEB_CLIENT_ID=<<xxxxxxxx>>
 
 # Capable Health API endpoint
@@ -31,3 +32,5 @@ REACT_APP_NAME='Capable Care'
 
 # Capable
 REACT_APP_WELLNESS_SURVEY_ID='<<xxxxxxxx>>'
+# Only value with current functionality is 'demo'
+REACT_APP_USAGE_MODE=

--- a/.env.sample
+++ b/.env.sample
@@ -31,6 +31,8 @@ REACT_APP_FAVICON='https://<<xxxxxxxx>>'
 REACT_APP_NAME='Capable Care'
 
 # Capable
-REACT_APP_WELLNESS_SURVEY_ID='<<xxxxxxxx>>'
+# Will be used to render a survey in the Profile section if present
+REACT_APP_WELLNESS_SURVEY_ID=
+# Indicates whether app is being used for Capable demo purposes
 # Only value with current functionality is 'demo'
 REACT_APP_USAGE_MODE=

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -122,6 +122,8 @@ export default function Profile({ signOut }) {
     signOut();
   };
 
+  console.log(process.env.REACT_APP_CAPABLE_DEMO);
+
   return (
     <>
       <BasicModal
@@ -154,6 +156,7 @@ export default function Profile({ signOut }) {
         />
       </Container>
 
+    {process.env.REACT_APP_USAGE_MODE === 'demo' && (
       <Container sx={{ marginTop: 3 }}>
         <Typography variant="h6" component="h2">
           My Information
@@ -207,6 +210,7 @@ export default function Profile({ signOut }) {
           </List>
         </StyledCard>
       </Container>
+    )}
 
       <Container sx={{ marginTop: 3 }}>
         <StyledCard sx={{ paddingY: 0 }}>

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -121,8 +121,77 @@ export default function Profile({ signOut }) {
     navigate("/");
     signOut();
   };
+  const MyInformation = ({ usageMode, surveyId }) => {
+    const components = [];
+    if (surveyId !== "") {
+      components.push(
+        <IconListLink
+          icon={<WellnessIcon />}
+          text="Wellness Profile"
+          onClick={() => navigate("/survey")}
+        />
+      );
+    }
+    if (usageMode === "demo") {
+      components.push(
+        <IconListLink
+          icon={<AllergiesIcon />}
+          text="Allergies"
+          onClick={() =>
+            handleOpenModal("This section may be populated by intake survey")
+          }
+        />
+      );
+      components.push(
+        <IconListLink
+          icon={<MedicationsIcon />}
+          text="Current Medications"
+          onClick={() =>
+            handleOpenModal(
+              "This section may be populated by observations recorded by patient"
+            )
+          }
+        />
+      );
+      components.push(
+        <IconListLink
+          icon={<VitalsIcon />}
+          text="Vitals & Trends"
+          onClick={() =>
+            handleOpenModal(
+              "This section may be populated by observations recorded by patient"
+            )
+          }
+        />
+      );
+      components.push(
+        <IconListLink
+          icon={<PreferencesIcon />}
+          text="Care preferences"
+          onClick={() =>
+            handleOpenModal("This section may launch a questionnaire")
+          }
+        />
+      );
+    }
+    if (components.length !== 0) {
+      return (
+        <Container sx={{ marginTop: 3 }}>
+          <Typography variant="h6" component="h2">
+            My Information
+          </Typography>
 
-  console.log(process.env.REACT_APP_CAPABLE_DEMO);
+          <StyledCard sx={{ paddingY: 0 }}>
+            <List>
+              {components.reduce((prev, curr) => [prev, <Divider />, curr])}
+            </List>
+          </StyledCard>
+        </Container>
+      );
+    } else {
+      return null;
+    }
+  };
 
   return (
     <>
@@ -156,61 +225,10 @@ export default function Profile({ signOut }) {
         />
       </Container>
 
-    {process.env.REACT_APP_USAGE_MODE === 'demo' && (
-      <Container sx={{ marginTop: 3 }}>
-        <Typography variant="h6" component="h2">
-          My Information
-        </Typography>
-
-        <StyledCard sx={{ paddingY: 0 }}>
-          <List>
-            <IconListLink
-              icon={<WellnessIcon />}
-              text="Wellness Profile"
-              onClick={() => navigate("/survey")}
-            />
-            <Divider />
-            <IconListLink
-              icon={<AllergiesIcon />}
-              text="Allergies"
-              onClick={() =>
-                handleOpenModal(
-                  "This section may be populated by intake survey"
-                )
-              }
-            />
-            <Divider />
-            <IconListLink
-              icon={<MedicationsIcon />}
-              text="Current Medications"
-              onClick={() =>
-                handleOpenModal(
-                  "This section may be populated by observations recorded by patient"
-                )
-              }
-            />
-            <Divider />
-            <IconListLink
-              icon={<VitalsIcon />}
-              text="Vitals & Trends"
-              onClick={() =>
-                handleOpenModal(
-                  "This section may be populated by observations recorded by patient"
-                )
-              }
-            />
-            <Divider />
-            <IconListLink
-              icon={<PreferencesIcon />}
-              text="Care preferences"
-              onClick={() =>
-                handleOpenModal("This section may launch a questionnaire")
-              }
-            />
-          </List>
-        </StyledCard>
-      </Container>
-    )}
+      <MyInformation
+        usageMode={process.env.REACT_APP_USAGE_MODE}
+        surveyId={process.env.REACT_APP_WELLNESS_SURVEY_ID}
+      />
 
       <Container sx={{ marginTop: 3 }}>
         <StyledCard sx={{ paddingY: 0 }}>


### PR DESCRIPTION
Adds an environment variable to specify whether the app is being used for Capable demo purposes. Using the new environment variable, adds logic to hide demo-only sections of the user Profile page if the app is not being used as a demo.

Also adds logic to hide the "Wellness Profile" section of the user Profile page based on whether a survey ID has been added as an environment variable.

https://app.shortcut.com/capable/story/6602/create-demo-flag-as-env-variable-hide-patient-pages-behind-flag#activity-6766